### PR TITLE
tinyfpga_bx: Fixup synthesis core config

### DIFF
--- a/data/tinyfpga_bx.pcf
+++ b/data/tinyfpga_bx.pcf
@@ -1,2 +1,25 @@
-set_io q A6
-set_io i_clk B2
+# Map pins for mor1kx toplevel module to the tinyfpga
+#
+# NOTE
+# Most pins we don't actually assign as we are just trying to get
+# synthesis to work and really don't care about PNR at the moment.
+
+set_io rst A6
+set_io clk B2
+
+# These are sb_io pins and must be mapped
+
+set_io traceport_exec_wbdata_o[12] A1
+set_io du_dat_i[22]                A7
+set_io iwbm_cti_o[0]               A8
+set_io multicore_numcores_i[18]    A9
+
+set_io du_stall_o                  B1
+# B2 used above
+set_io iwbm_dat_i[6]               B3
+set_io dwbm_dat_o[2]               B4
+set_io traceport_exec_insn_o[7]    B5
+set_io snoop_adr_i[21]             B6
+set_io dwbm_adr_o[30]              B7
+set_io snoop_adr_i[19]             B8
+set_io traceport_exec_wbdata_o[10] B9

--- a/mor1kx.core
+++ b/mor1kx.core
@@ -92,9 +92,9 @@ targets:
 
   tinyfpga_bx:
     default_tool : icestorm
-    filesets : [core, fpu, monitor, tinyfpga_bx]
+    filesets : [core, tinyfpga_bx]
     tools:
       icestorm:
-        nextpnr_options : [--lp8k, --package, cm81, --freq, 32]
+        nextpnr_options : [--lp8k, --pcf-allow-unconstrained, --package, cm81, --freq, 32]
         pnr: next
-    toplevel : core
+    toplevel : mor1kx


### PR DESCRIPTION
Changes to core:
 - remove fpu and monitor filesets
   * Monitor is not needed as its for simulation.
   * FPU synth is failing due to some flags yosys doesn't support, we can
     investigate later.
 - set top level verilog module to mor1kx

The synthesis runs now, but pnr fails with the below error:

  $ fusesoc run --target=tinyfpga_bx mor1kx
  ERROR: failed to place cell 'traceport_exec_insn_o[3]$sb_io' of type 'SB_IO'
  ERROR: Placing design failed.

I started adding the cells i.e. (traceport_exec_insn_o[3]) to the pcf
file at random pins just to see if we could get PNR to succeed, but I
think we will not have enough pins.

We don't really need the PNR to run so we have some options:
 1. Try to get olof's pnr: none option to work
 2. Keep PNR and add a simple wrapper module like data/toplevel.v to
    wrap mor1kx and wire most things to 1b'0.